### PR TITLE
Fix blue quota selection colors

### DIFF
--- a/core/css/styles.css
+++ b/core/css/styles.css
@@ -407,6 +407,11 @@ button, .button, select {
     background-color: #3daee9;
     color: #fcfcfc;
     border-color: #3daee9; }
+  button:active, .button:focus, .button:active, select:focus, select:active {
+    background-color: #31363b;
+    color: #eff0f1;
+    border-color: #3daee9;
+    }
   input[type="submit"]:disabled, input[type="button"]:disabled,
   button:disabled, .button:disabled, select:disabled {
     background-color: #4d4d4d; }


### PR DESCRIPTION
When selecting quota for a user, the drop down is blue. 
![2017-05-12 21_26_25-users - storage](https://cloud.githubusercontent.com/assets/10052885/26021747/d2a3fd6c-3759-11e7-9243-d55ce152e948.png)

I think it should look like this:
![2017-05-12 21_28_14-users - storage](https://cloud.githubusercontent.com/assets/10052885/26021754/f6b01d8a-3759-11e7-8c38-2c4ab5633f60.png)