### PR TITLE
Separate login page styling from enabled by default option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   Add weather_status app icon and notes app icon
 -   [#173](https://github.com/mwalbeck/nextcloud-breeze-dark/issues/173) Add support for Forms
 -   Add icon-view-list icon for Calendar
+-   [#155](https://github.com/mwalbeck/nextcloud-breeze-dark/issues/155) Allow Breeze Dark theming of the login page to be disabled.
 
 ### Fixed
 

--- a/css/server/_server.scss
+++ b/css/server/_server.scss
@@ -136,6 +136,11 @@
     }
 }
 
+// Breeze Dark settings
+.breezedark-admin p {
+    margin-top: 1em;
+}
+
 /* Tooltips ----------------------------------------------------------------- */
 
 .tooltip,

--- a/js/settings-admin.js
+++ b/js/settings-admin.js
@@ -26,14 +26,16 @@ window.addEventListener("DOMContentLoaded", function () {
     $("#breezedark-theme-enabled").change(function () {
         $.post(OC.generateUrl("apps/breezedark/settings/admin"), {
             theme_enabled: this.checked ? 1 : 0,
-            theme_login_page: $("#breezedark-theme-login-page").attr("checked") ? 1 : 0,
+            theme_login_page: $("#breezedark-theme-login-page").prop("checked") ? 1 : 0,
         });
+
+        $("#breezedark-theme-login-page").prop("disabled", !$("#breezedark-theme-enabled").prop("checked"))
     });
 
     $("#breezedark-theme-login-page").change(function () {
         $.post(OC.generateUrl("apps/breezedark/settings/admin"), {
             theme_login_page: this.checked ? 1 : 0,
-            theme_enabled: $("#breezedark-theme-enabled").attr("checked") ? 1 : 0,
+            theme_enabled: $("#breezedark-theme-enabled").prop("checked") ? 1 : 0,
         });
     });
 });

--- a/js/settings-admin.js
+++ b/js/settings-admin.js
@@ -23,9 +23,17 @@
  */
 
 window.addEventListener("DOMContentLoaded", function () {
-    $("#breezedark-enabled").change(function () {
+    $("#breezedark-theme-enabled").change(function () {
         $.post(OC.generateUrl("apps/breezedark/settings/admin"), {
             theme_enabled: this.checked ? 1 : 0,
+            theme_login_page: $("#breezedark-theme-login-page").attr("checked") ? 1 : 0,
+        });
+    });
+
+    $("#breezedark-theme-login-page").change(function () {
+        $.post(OC.generateUrl("apps/breezedark/settings/admin"), {
+            theme_login_page: this.checked ? 1 : 0,
+            theme_enabled: $("#breezedark-theme-enabled").attr("checked") ? 1 : 0,
         });
     });
 });

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -79,5 +79,11 @@ class SettingsController extends Controller {
         } else {
             $this->config->setAppValue($this->appName, "theme_enabled", "0");
         }
+
+        if ($this->request->getParam("theme_login_page")) {
+            $this->config->setAppValue($this->appName, "theme_login_page", "1");
+        } else {
+            $this->config->setAppValue($this->appName, "theme_login_page", "0");
+        }
     }
 }

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -53,8 +53,10 @@ class Admin implements ISettings {
      */
     public function getForm() {
         $themeEnabled = $this->config->getAppValue($this->appName, 'theme_enabled', "0");
+        $themeLoginPage = $this->config->getAppValue($this->appName, 'theme_login_page', "1");
         return new TemplateResponse('breezedark', 'admin', [ 
-            "themeEnabled" => $themeEnabled
+            "themeEnabled" => $themeEnabled,
+            "themeLoginPage" => $themeLoginPage
         ]);
     }
 

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -31,6 +31,9 @@ script('breezedark', 'settings-admin');
     <h2><?php p($l->t("Breeze Dark")); ?></h2>
     <p><?php p($l->t("A Dark theme based on Breeze Dark by the KDE project. Please refresh the page for changes to take effect.")); ?></p>
     <p><?php p($l->t("This setting will enable the theme by default, for any unauthenticated users and users who haven't set a preference.")); ?></p>
-    <input type="checkbox" class="checkbox" id="breezedark-enabled" <?php p($themeEnabled ? "checked" : ""); ?>>
-    <label for="breezedark-enabled"><?php p($l->t("Enable Breeze Dark theme by default")); ?></label>
+    <input type="checkbox" class="checkbox" id="breezedark-theme-enabled" <?php p($themeEnabled ? "checked" : ""); ?>>
+    <label for="breezedark-theme-enabled"><?php p($l->t("Enable Breeze Dark theme by default")); ?></label>
+    <p><?php p($l->t("This setting will allow you to choose if the login page should be theme when the theme is enabled by default")); ?></p>
+    <input type="checkbox" class="checkbox" id="breezedark-theme-login-page" <?php p($themeEnabled ? "" : "disabled");?> <?php p($themeLoginPage ? "checked" : "");?>>
+    <label for="breezedark-theme-login-page"><?php p($l->t("Theme the login page")); ?></label>
 </div>

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -27,13 +27,13 @@
 script('breezedark', 'settings-admin');
 ?>
 
-<div id="breezedark" class="section">
+<div id="breezedark" class="breezedark-admin section">
     <h2><?php p($l->t("Breeze Dark")); ?></h2>
     <p><?php p($l->t("A Dark theme based on Breeze Dark by the KDE project. Please refresh the page for changes to take effect.")); ?></p>
     <p><?php p($l->t("This setting will enable the theme by default, for any unauthenticated users and users who haven't set a preference.")); ?></p>
     <input type="checkbox" class="checkbox" id="breezedark-theme-enabled" <?php p($themeEnabled ? "checked" : ""); ?>>
     <label for="breezedark-theme-enabled"><?php p($l->t("Enable Breeze Dark theme by default")); ?></label>
-    <p><?php p($l->t("This setting will allow you to choose if the login page should be theme when the theme is enabled by default")); ?></p>
+    <p><?php p($l->t("This setting will allow you to choose if the login page should be themed when the theme is enabled by default")); ?></p>
     <input type="checkbox" class="checkbox" id="breezedark-theme-login-page" <?php p($themeEnabled ? "" : "disabled");?> <?php p($themeLoginPage ? "checked" : "");?>>
     <label for="breezedark-theme-login-page"><?php p($l->t("Theme the login page")); ?></label>
 </div>

--- a/templates/personal.php
+++ b/templates/personal.php
@@ -27,7 +27,7 @@
 script('breezedark', 'settings-personal');
 ?>
 
-<div id="breezedark" class="section">
+<div id="breezedark" class="breezedark-personal section">
     <h2><?php p($l->t("Breeze Dark")); ?></h2>
     <p><?php p($l->t("A Breeze Dark theme for Nextcloud.")); ?></p>
     <div class="preview-list">


### PR DESCRIPTION
* [x] Disable checkbox for theme login page, instantly with js
* [x] Create logic for adding the guest.css only when wanted.