### PR TITLE
Don't invert app icons in app store sidebar. Fixes #218

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 -   [#152](https://github.com/mwalbeck/nextcloud-breeze-dark/issues/152) Styling for PhoneTrack
 -   [#166](https://github.com/mwalbeck/nextcloud-breeze-dark/issues/166) Styling for GpxMotion and adjust link colour for PhoneTrack
 
+### Fixed
+
+-   [#218](https://github.com/mwalbeck/nextcloud-breeze-dark/issues/218) Don't invert app icons in app store sidebar
+
 ## 20.0.6 - 2021-02-23
 
 ### Fixed

--- a/css/apps/_apps.scss
+++ b/css/apps/_apps.scss
@@ -42,6 +42,12 @@
     box-shadow: none !important;
 }
 
+/* App Store ---------------------------------------------------------------- */
+
+.app-settings #app-sidebar-vue .app-sidebar-header__figure {
+    filter: invert(5%);
+}
+
 /* CodeMirror --------------------------------------------------------------- */
 
 .EasyMDEContainer .CodeMirror {


### PR DESCRIPTION
(cherry picked from commit a96b0ccd0d5770899e03fc664202c76eff2a5eca)