### PR TITLE
Add the 'icon-view-previous' icon

### DIFF
--- a/css/server/_icons.scss
+++ b/css/server/_icons.scss
@@ -319,7 +319,9 @@ div.select2-container a.select2-choice .select2-arrow b {
     background-image: var(--icon-arrow-right-f2f2f2) !important;
 }
 
-.icon-arrow-left {
+
+.icon-arrow-left,
+.icon-view-previous {
     background-image: var(--icon-arrow-left-f2f2f2) !important;
 }
 

--- a/css/server/_icons.scss
+++ b/css/server/_icons.scss
@@ -319,7 +319,6 @@ div.select2-container a.select2-choice .select2-arrow b {
     background-image: var(--icon-arrow-right-f2f2f2) !important;
 }
 
-
 .icon-arrow-left,
 .icon-view-previous {
     background-image: var(--icon-arrow-left-f2f2f2) !important;


### PR DESCRIPTION
I use both the icon-view-next and icon-view-previous in my app and only the icon-view-next is displayed correctly. I added it to the _icons.scss file. I hope, that doesn't brake any other apps.