### PR TITLE
Add repair steps to cleanup / restore theme settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+-   [#330](https://github.com/mwalbeck/nextcloud-breeze-dark/issues/330) Cleanup enabled-themes and enforce_theme settings during uninstall / disable of app to allow for uninstalling / disabling the app without first having to disable the theme. Settings will be restored when installing / enabling the app.
+
 ## 25.0.1 - 2023-02-28
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -53,6 +53,12 @@ Under the Theming section in the admin settings you can add your own custom styl
 		<post-migration>
 			<step>OCA\BreezeDark\Migration\MigrateUserThemeSettings</step>
 		</post-migration>
+        <install>
+            <step>OCA\BreezeDark\Migration\InstallRestoreSettings</step>
+        </install>
+        <uninstall>
+            <step>OCA\BreezeDark\Migration\UninstallCleanup</step>
+        </uninstall>
 	</repair-steps>
     <settings>
         <personal>OCA\BreezeDark\Settings\Personal</personal>

--- a/lib/Migration/InstallRestoreSettings.php
+++ b/lib/Migration/InstallRestoreSettings.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Breeze Dark theme for Nextcloud
+ *
+ * @copyright Copyright (C) 2023  Magnus Walbeck <mw@mwalbeck.org>
+ *
+ * @author Magnus Walbeck <mw@mwalbeck.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\BreezeDark\Migration;
+
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class InstallRestoreSettings implements IRepairStep
+{
+    /** @var IDBConnection */
+	private $db;
+
+    /** @var IConfig */
+	private $config;
+
+    public function __construct(IDBConnection $db, IConfig $config)
+    {
+        $this->db = $db;
+        $this->config = $config;   
+    }
+
+    public function getName(): string
+    {
+        return "Restore enabled-themes and enforce_theme settings that where removed during an uninstall";
+    }
+
+    public function run(IOutput $output): void
+    {
+        $userQb = $this->db->getQueryBuilder();
+        $userQb->select('userid')->from('preferences')->where(
+            $userQb->expr()->eq('appid', $userQb->createNamedParameter('breezedark'), IQueryBuilder::PARAM_STR),
+            $userQb->expr()->eq('configkey', $userQb->createNamedParameter('theme_enabled')),
+            $userQb->expr()->eq('configvalue', $userQb->createNamedParameter('1'))
+        );
+        $result = $userQb->executeQuery();
+
+        $users = $result->fetchAll();
+
+        foreach($users as $user) {
+            $enabledThemes = json_decode($this->config->getUserValue($user["userid"], "theming", "enabled-themes", "[]"));
+            $enabledThemes = array_merge(["breezedark"], $enabledThemes);
+            $this->config->setUserValue($user["userid"], "theming", "enabled-themes", json_encode(array_values(array_unique($enabledThemes))));
+        }
+
+        $themeEnforced = $this->config->getAppValue("breezedark", "theme_enforced", "0");
+        $currentEnforcedTheme = $this->config->getSystemValue("enforce_theme", "");
+
+        if ($themeEnforced && $currentEnforcedTheme === "") {
+            // Re-enable enforcement of the theme if no enforced theme is currently set
+            $this->config->setSystemValue("enforce_theme", "breezedark");
+        } elseif ($themeEnforced && $currentEnforcedTheme !== "breezedark") {
+            // Disable theme enforcement of breezedark if a theme other than
+            // breezedark is currently being enforced
+            $this->config->setAppValue("breezedark", "theme_enforced", "0");
+        }
+    }
+}

--- a/lib/Migration/UninstallCleanup.php
+++ b/lib/Migration/UninstallCleanup.php
@@ -70,7 +70,7 @@ class UninstallCleanup implements IRepairStep
 
             $key = array_search("breezedark", $enabledThemes);
 
-            if ($key) {
+            if ($key !== false) {
                 unset($enabledThemes[$key]);
             }
 
@@ -83,6 +83,10 @@ class UninstallCleanup implements IRepairStep
         // Disable enforcement of the theme if the current enforced theme is breezedark
         if ($themeEnforced && $currentEnforcedTheme === "breezedark") {
             $this->config->setSystemValue("enforce_theme", "");
+        } elseif ($themeEnforced && $currentEnforcedTheme !== "breezedark") {
+            // Disable theme enforcement of breezedark if a theme other than
+            // breezedark is currently being enforced
+            $this->config->setAppValue("breezedark", "theme_enforced", "0");
         }
     }
 }

--- a/lib/Migration/UninstallCleanup.php
+++ b/lib/Migration/UninstallCleanup.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Breeze Dark theme for Nextcloud
+ *
+ * @copyright Copyright (C) 2023  Magnus Walbeck <mw@mwalbeck.org>
+ *
+ * @author Magnus Walbeck <mw@mwalbeck.org>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\BreezeDark\Migration;
+
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class UninstallCleanup implements IRepairStep
+{
+    /** @var IDBConnection */
+	private $db;
+
+    /** @var IConfig */
+	private $config;
+
+    public function __construct(IDBConnection $db, IConfig $config)
+    {
+        $this->db = $db;
+        $this->config = $config;   
+    }
+
+    public function getName(): string
+    {
+        return "Cleanup enabled-themes and enforce_theme settings to prevent issues after an uninstall.";
+    }
+
+    public function run(IOutput $output): void
+    {
+        $userQb = $this->db->getQueryBuilder();
+        $userQb->select('userid')->from('preferences')->where(
+            $userQb->expr()->eq('appid', $userQb->createNamedParameter('breezedark'), IQueryBuilder::PARAM_STR),
+            $userQb->expr()->eq('configkey', $userQb->createNamedParameter('theme_enabled')),
+            $userQb->expr()->eq('configvalue', $userQb->createNamedParameter('1'))
+        );
+        $result = $userQb->executeQuery();
+
+        $users = $result->fetchAll();
+
+        foreach($users as $user) {
+            $enabledThemes = json_decode($this->config->getUserValue($user["userid"], "theming", "enabled-themes", "[]"));
+
+            $key = array_search("breezedark", $enabledThemes);
+
+            if ($key) {
+                unset($enabledThemes[$key]);
+            }
+
+            $this->config->setUserValue($user["userid"], "theming", "enabled-themes", json_encode(array_values(array_unique($enabledThemes))));
+        }
+
+        $themeEnforced = $this->config->getAppValue("breezedark", "theme_enforced", "0");
+        $currentEnforcedTheme = $this->config->getSystemValue("enforce_theme", "");
+
+        // Disable enforcement of the theme if the current enforced theme is breezedark
+        if ($themeEnforced && $currentEnforcedTheme === "breezedark") {
+            $this->config->setSystemValue("enforce_theme", "");
+        }
+    }
+}


### PR DESCRIPTION
Add repair steps to cleanup / restore enabled_themes and enforce_theme settings during uninstall / install to prevent theming issues caused by breezedark still being an enabled theme unless you disable the theme first before uninstall the app

- [x] Test uninstall repair step
- [x] Test install repair step